### PR TITLE
Fix header null check in service worker

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -199,12 +199,14 @@ async function networkFirstStrategy(request, cacheName) {
   }
   
   // If both network and cache fail, return a custom offline response
-  if (request.headers.get('accept').includes('text/html')) {
+  const acceptHeader = request.headers.get('accept') || '';
+
+  if (acceptHeader.includes('text/html')) {
     return caches.match('/offline.html');
   }
-  
+
   // For images, return offline image
-  if (request.headers.get('accept').includes('image/')) {
+  if (acceptHeader.includes('image/')) {
     return caches.match('/offline.svg');
   }
   


### PR DESCRIPTION
## Summary
- prevent crashes in Service Worker when requests lack `Accept` header

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_68874a5356108322b7a9cddf7333e8ee